### PR TITLE
fix: Incorrect order of indices used in TSPTW model

### DIFF
--- a/2025/tsptw/tsptw.mzn
+++ b/2025/tsptw/tsptw.mzn
@@ -30,7 +30,7 @@ int: depot = 1; % The first location is the depot
 array[Locations] of var Locations: pred;
 % durToPred[l] = the distance from location pred[l] to location l:
 array[Locations] of var 0..max(duration): durToPred = [
-    duration[l, pred[l]] | l in Locations];
+    duration[pred[l], l] | l in Locations];
 % arrival[l] = the arrival at location l:
 array[Locations] of var 0..max(late): arrival;
 % departure[l] = the departure at location l:


### PR DESCRIPTION
The indexing used in the `tsptw.mzn` model from the 2025 challenge uses the wrong order for the indices defining `durToPred`.

While this does not lead to any incorrect solutions when using a symmetric distance matrix (as is the case for all the instances in the 2025 MiniZinc Challenge), it does lead to issues on other instance sets in the literature.

_This fix does not lead to any changes in the produced flatzinc file for the instances used in the challenge, but it might be able to prevent people from running into this issue when reusing this model!_